### PR TITLE
提高被重试下载的图片的优先级

### DIFF
--- a/e-Hentai/PhotoViewController/PhotoViewController.m
+++ b/e-Hentai/PhotoViewController/PhotoViewController.m
@@ -186,7 +186,7 @@
 }
 
 - (void)createNewOperation:(NSString *)urlString {
-    [self createNewOperation:urlString isHighPrior:false];
+    [self createNewOperation:urlString isHighPrior:NO];
 }
 
 - (void)createNewOperation:(NSString *)urlString isHighPrior:(BOOL)isHighPrior {
@@ -196,12 +196,7 @@
     newOperation.hentaiKey = self.hentaiKey;
     newOperation.delegate = self;
     newOperation.isHighResolution = self.isHighResolution;
-    if (isHighPrior) {
-        [newOperation setQueuePriority:NSOperationQueuePriorityHigh];
-    }
-    else {
-        [newOperation setQueuePriority:NSOperationQueuePriorityNormal];
-    }
+    newOperation.queuePriority = isHighPrior ?  NSOperationQueuePriorityHigh : NSOperationQueuePriorityNormal;
     [self.hentaiQueue addOperation:newOperation];
 }
 
@@ -258,7 +253,7 @@
         self.retryMap[urlString] = retryCount;
         
         if ([retryCount integerValue] <= [[Setting shared].retryTimes integerValue]) {
-            [self createNewOperation:urlString isHighPrior:true];
+            [self createNewOperation:urlString isHighPrior:YES];
         }
         else {
             self.failCount++;

--- a/e-Hentai/PhotoViewController/PhotoViewController.m
+++ b/e-Hentai/PhotoViewController/PhotoViewController.m
@@ -186,12 +186,22 @@
 }
 
 - (void)createNewOperation:(NSString *)urlString {
+    [self createNewOperation:urlString isHighPrior:false];
+}
+
+- (void)createNewOperation:(NSString *)urlString isHighPrior:(BOOL)isHighPrior {
     HentaiDownloadImageOperation *newOperation = [HentaiDownloadImageOperation new];
     newOperation.downloadURLString = urlString;
     newOperation.isCacheOperation = YES;
     newOperation.hentaiKey = self.hentaiKey;
     newOperation.delegate = self;
     newOperation.isHighResolution = self.isHighResolution;
+    if (isHighPrior) {
+        [newOperation setQueuePriority:NSOperationQueuePriorityHigh];
+    }
+    else {
+        [newOperation setQueuePriority:NSOperationQueuePriorityNormal];
+    }
     [self.hentaiQueue addOperation:newOperation];
 }
 
@@ -248,7 +258,7 @@
         self.retryMap[urlString] = retryCount;
         
         if ([retryCount integerValue] <= [[Setting shared].retryTimes integerValue]) {
-            [self createNewOperation:urlString];
+            [self createNewOperation:urlString isHighPrior:true];
         }
         else {
             self.failCount++;


### PR DESCRIPTION
避免被重试下载的图片任务卡在之前一次提交的20张图片下载队列后面，导致用户界面卡住滚不下去。