### PR TITLE
搜索界面添加“中文”关键字

### DIFF
--- a/Dai-Hentai/Models/DaiStorageModels/SearchInfo/SearchInfo.h
+++ b/Dai-Hentai/Models/DaiStorageModels/SearchInfo/SearchInfo.h
@@ -22,6 +22,7 @@
 @property (nonatomic, strong) NSNumber *cosplay;
 @property (nonatomic, strong) NSNumber *asianporn;
 @property (nonatomic, strong) NSNumber *misc;
+@property (nonatomic, strong) NSNumber *isChinese;
 
 - (instancetype)initWithDictionary:(NSDictionary<NSString *, id> *)dictionary;
 - (NSString *)query:(NSInteger)page;

--- a/Dai-Hentai/Models/DaiStorageModels/SearchInfo/SearchInfo.m
+++ b/Dai-Hentai/Models/DaiStorageModels/SearchInfo/SearchInfo.m
@@ -14,7 +14,8 @@
 #pragma mark - Instance Method
 
 - (NSString *)query:(NSInteger)page {
-    NSMutableString *query = [NSMutableString stringWithFormat:@"?page=%@&f_doujinshi=%@&f_manga=%@&f_artistcg=%@&f_gamecg=%@&f_western=%@&f_non-h=%@&f_imageset=%@&f_cosplay=%@&f_asianporn=%@&f_misc=%@&f_search=%@&f_apply=Apply+Filter", @(page), self.doujinshi, self.manga, self.artistcg, self.gamecg, self.western, self.non_h, self.imageset, self.cosplay, self.asianporn, self.misc, [[self.keyword componentsSeparatedByString:@" "] componentsJoinedByString:@"+"]];
+    NSString *keywordWithChinese = [self.isChinese isEqual:@(1)]?[self.keyword stringByAppendingString:@" language:Chinese"]:self.keyword;
+    NSMutableString *query = [NSMutableString stringWithFormat:@"?page=%@&f_doujinshi=%@&f_manga=%@&f_artistcg=%@&f_gamecg=%@&f_western=%@&f_non-h=%@&f_imageset=%@&f_cosplay=%@&f_asianporn=%@&f_misc=%@&f_search=%@&f_apply=Apply+Filter", @(page), self.doujinshi, self.manga, self.artistcg, self.gamecg, self.western, self.non_h, self.imageset, self.cosplay, self.asianporn, self.misc, [[keywordWithChinese componentsSeparatedByString:@" "] componentsJoinedByString:@"+"]];
     
     if ([self.rating compare:@(0)] != NSOrderedSame) {
         [query appendFormat:@"&advsearch=1&f_sname=on&f_stags=on&f_sr=on&f_srdd=%@", @(self.rating.integerValue + 1)];
@@ -62,6 +63,7 @@
         self.cosplay = @(1);
         self.asianporn = @(1);
         self.misc = @(1);
+        self.isChinese = @(0);
     }
     return self;
 }

--- a/Dai-Hentai/ViewControllers/SearchViewController/SearchViewController.m
+++ b/Dai-Hentai/ViewControllers/SearchViewController/SearchViewController.m
@@ -207,6 +207,7 @@ typedef enum {
     [self.allItems addObject:rate];
     
     NSMutableArray<SearchItem *> *categories = [NSMutableArray array];
+    [categories addObject:[SearchItem itemWith:@"Chinese" getter:@"isChinese"]];
     [categories addObject:[SearchItem itemWith:@"Doujinshi" getter:@"doujinshi"]];
     [categories addObject:[SearchItem itemWith:@"Manga" getter:@"manga"]];
     [categories addObject:[SearchItem itemWith:@"Artist CG" getter:@"artistcg"]];

--- a/Dai-Hentai/ViewControllers/SearchViewController/SearchViewController.m
+++ b/Dai-Hentai/ViewControllers/SearchViewController/SearchViewController.m
@@ -168,6 +168,11 @@ typedef enum {
         }
     }
     
+    NSArray<NSString *> *badWords = [NSArray arrayWithObjects:@"chinese",@"translated",@"中国翻訳", nil];
+    for (NSString *item in badWords) {
+        [recentKeywords removeObjectForKey:item];
+    }
+    
     // 依照出現的次數多 -> 寡排序
     return [recentKeywords keysSortedByValueUsingComparator:^NSComparisonResult(NSNumber *obj1, NSNumber *obj2) {
         return [obj2 compare:obj1];


### PR DESCRIPTION
多一个叫做 Chinese 的作品类别，并在 tag 和标题里去掉 `chinese` `translated` `中国翻訳` 这样的字。
相关 #76 
其实把 Chinese 放在上面近期 tag 里可能效果更好？

另外，现在从近期 tag 里选中的关键字会出现在最上面的`手动输入关键字`的搜索框里