### PR TITLE
Change UIUserInterfaceStyle to Light

### DIFF
--- a/Dai-Hentai/Info.plist
+++ b/Dai-Hentai/Info.plist
@@ -67,6 +67,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIUserInterfaceStyle</key>
-	<string>light</string>
+	<string>Light</string>
 </dict>
 </plist>


### PR DESCRIPTION
根据[此处](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/iPhoneOSKeys.html#//apple_ref/doc/uid/TP40009252-SW44)的描述，UIUserInterfaceStyle应为"Automatic", "Light", "Dark"中的一项，light不是一个有效值。